### PR TITLE
Fix Alarm startOffset storage

### DIFF
--- a/src/itemcalendars.cpp
+++ b/src/itemcalendars.cpp
@@ -65,7 +65,7 @@ static KCalendarCore::Alarm::Ptr toAlarm(KCalendarCore::Incidence::Ptr incidence
                                          const QOrganizerItemReminder &reminder)
 {
     KCalendarCore::Alarm::Ptr alarm = incidence->newAlarm();
-    alarm->setStartOffset(KCalendarCore::Duration(reminder.secondsBeforeStart()));
+    alarm->setStartOffset(KCalendarCore::Duration(-reminder.secondsBeforeStart()));
     alarm->setRepeatCount(reminder.repetitionCount());
     alarm->setSnoozeTime(KCalendarCore::Duration(reminder.repetitionDelay()));
 
@@ -405,7 +405,7 @@ static void updateJournal(KCalendarCore::Journal::Ptr journal,
 static void toItemReminder(QOrganizerItemReminder *reminder,
                            const KCalendarCore::Alarm::Ptr &alarm)
 {
-    reminder->setSecondsBeforeStart(alarm->startOffset().asSeconds());
+    reminder->setSecondsBeforeStart(-alarm->startOffset().asSeconds());
     reminder->setRepetition(alarm->repeatCount(), alarm->snoozeTime().asSeconds());
 }
 

--- a/tests/tst_engine.cpp
+++ b/tests/tst_engine.cpp
@@ -577,7 +577,7 @@ void tst_engine::testItemAudibleReminder()
     KCalendarCore::Alarm::Ptr alarm = incidence->alarms().first();
     QCOMPARE(alarm->type(), KCalendarCore::Alarm::Audio);
     QCOMPARE(alarm->audioFile(), detail.dataUrl().toString());
-    QCOMPARE(alarm->startOffset().asSeconds(), detail.secondsBeforeStart());
+    QCOMPARE(alarm->startOffset().asSeconds(), -detail.secondsBeforeStart());
     QVERIFY(!alarm->hasEndOffset());
     QCOMPARE(alarm->snoozeTime().asSeconds(), detail.repetitionDelay());
     QCOMPARE(alarm->repeatCount(), detail.repetitionCount());


### PR DESCRIPTION
QtPim QOrganizer express the Alarm trigger offset as secondsBeforeStart() only. When positive, offset must be converted to a negative offset in mkCal, and vice and versa