### PR TITLE
CMakeLists.txt: Make installation of tests optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
 include(FeatureSummary)
 include(GNUInstallDirs)
 
+option(INSTALL_TESTS "Install the tests on make install" ON)
+
 set(QT_MIN_VERSION "5.6.0")
 find_package(Qt5 ${QT_MIN_VERSION} COMPONENTS Organizer Test REQUIRED)
 find_package(KF5 COMPONENTS CalendarCore REQUIRED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,4 +8,6 @@ target_link_libraries(tst_engine
 
 add_test(tst_engine tst_engine)
 
-install(TARGETS tst_engine DESTINATION /opt/tests/qtorganizer-mkcal)
+if(INSTALL_TESTS)
+	install(TARGETS tst_engine DESTINATION /opt/tests/qtorganizer-mkcal)
+endif()


### PR DESCRIPTION
1. Not everyone needs them after building & running the tests.
2. The hardcoded location may be unsuitable for the environment, maybe this should use a `CMAKE_INSTALL_*DIR`-relative location? Just disabling the installation works for now.