### PR TITLE
Don't install tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ include(CTest)
 include(FeatureSummary)
 include(GNUInstallDirs)
 
-option(INSTALL_TESTS "Install the tests on make install" ON)
-
 set(QT_MIN_VERSION "5.6.0")
 find_package(Qt5 ${QT_MIN_VERSION} COMPONENTS Organizer Test REQUIRED)
 find_package(KF5 COMPONENTS CalendarCore REQUIRED)

--- a/rpm/qtorganizer-mkcal.spec
+++ b/rpm/qtorganizer-mkcal.spec
@@ -33,6 +33,7 @@ make %{?_smp_mflags}
 
 %install
 make DESTDIR=%{buildroot} install
+install -m 644 -p -D tests/tst_engine %{buildroot}/opt/tests/qtorganizer-mkcal
 
 %files
 %defattr(-,root,root,-)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,3 @@ target_link_libraries(tst_engine
         KF5::CalendarCore)
 
 add_test(tst_engine tst_engine)
-
-if(INSTALL_TESTS)
-	install(TARGETS tst_engine DESTINATION /opt/tests/qtorganizer-mkcal)
-endif()


### PR DESCRIPTION
Copy test executables in the packaging recipes instead.

@OPNA2608 may I ask you, if I remove the test installation completely, does it work for you also ? Looking on the Internet, for the best practices, it seems to me that actually tests are not supposed to be installed. There is no directory variables in GNUInstallDirs for instance.

So I propose to instead do the installation in the packaging scripts.