### PR TITLE
Clean mRunningRequest on requestDestroyed

### DIFF
--- a/src/mkcalplugin.cpp
+++ b/src/mkcalplugin.cpp
@@ -479,7 +479,10 @@ void mKCalEngine::processRequests()
 void mKCalEngine::requestDestroyed(QOrganizerAbstractRequest *request)
 {
     if (mRunningRequest == request) {
+        disconnect(mRunningRequest, &QOrganizerAbstractRequest::resultsAvailable,
+                   this, &mKCalEngine::processRequests);
         request->waitForFinished();
+        mRunningRequest = nullptr;
     } else if (mRequests.contains(request)) {
         cancelRequest(request);
     }


### PR DESCRIPTION
On lomiri-clock-app 26.04, we have crash when removing an alarm.
https://gitlab.com/ubports/development/apps/lomiri-clock-app/-/work_items/205

It appears mRunningRequest become a dangling pointer when reaching processRequests